### PR TITLE
App ID scripts modifications

### DIFF
--- a/scripts/createappid.sh
+++ b/scripts/createappid.sh
@@ -63,7 +63,7 @@ echo $response
 code=$(echo "${response}" | tail -n1)
 [ "$code" -ne "200" ] && printf "\nFAILED to create application\n" && exit 1
 
-clientid=$(echo "${response}" | head -n-1 | jq -j '.clientId')
+clientid=$(echo "${response}" | head -n1 | jq -j '.clientId')
 
 printf "\nDefining admin scope\n"
 response=$(curl -X PUT -w "\n%{http_code}" \
@@ -93,7 +93,7 @@ echo $response
 code=$(echo "${response}" | tail -n1)
 [ "$code" -ne "201" ] && printf "\nFAILED to define admin role\n" && exit 1
 
-roleid=$(echo "${response}" | head -n-1 | jq -j '.id')
+roleid=$(echo "${response}" | head -n1 | jq -j '.id')
 
 printf "\nDefining admin user in cloud directory\n"
 response=$(curl -X POST -w "\n%{http_code}" \
@@ -125,7 +125,7 @@ echo $response
 code=$(echo "${response}" | tail -n1)
 [ "$code" -ne "200" ] && printf "\nFAILED to get admin user profile\n" && exit 1
 
-userid=$(echo "${response}" | head -n-1 | jq -j '.users[0].id')
+userid=$(echo "${response}" | head -n1 | jq -j '.users[0].id')
 
 printf "\nAdding admin role to admin user\n"
 response=$(curl -X PUT -w "\n%{http_code}" \

--- a/scripts/createappid.sh
+++ b/scripts/createappid.sh
@@ -1,3 +1,23 @@
+# Check if ibmcloud is in user's account
+ibmcloud_accountname=$(ibmcloud target --output json | jq -j '.account.name')
+
+## check if account is in quicklabs (labs.cognitiveclass.ai) or workshop clusters account in DEG
+if [ "$ibmcloud_accountname" = "QuickLabs - IBM Skills Network" ]; then
+  echo "\n"
+  echo "WARNING: You're logged in as ${ibmcloud_accountname}"
+  echo "Please log in again using -- ibmcloud login -u YOUR_IBM_CLOUD_EMAIL"
+  echo "and run this script again"
+  exit 1
+elif [ "$ibmcloud_accountname" = "DEGCloud DEGCloud's Account" ]; then
+  echo "\n"
+  echo "WARNING: You're logged in as ${ibmcloud_accountname}"
+  echo "Please log in again using -- ibmcloud login -u YOUR_IBM_CLOUD_EMAIL"
+  echo "and run this script again"
+  exit 1
+fi
+# end check
+
+
 RG=$(ibmcloud resource groups --default | grep -i ^default | awk '{print $1}')
 ibmcloud target -g $RG
 

--- a/scripts/createsecrets.sh
+++ b/scripts/createsecrets.sh
@@ -13,7 +13,7 @@ echo $response
 code=$(echo "${response}" | tail -n1)
 [ "$code" -ne "200" ] && exit 1
 
-accesstoken=$(echo "${response}" | head -n-1 | jq -j '.access_token')
+accesstoken=$(echo "${response}" | head -n1 | jq -j '.access_token')
 
 response=$(curl -v -X GET -w "\n%{http_code}" \
   -H "Content-Type: application/json" \
@@ -25,10 +25,10 @@ echo $response
 code=$(echo "${response}" | tail -n1)
 [ "$code" -ne "200" ] && exit 1
 
-tenantid=$(echo "${response}"| head -n-1 | jq -j '.applications[0].tenantId')
-clientid=$(echo "${response}"| head -n-1 | jq -j '.applications[0].clientId')
-secret=$(echo "${response}"| head -n-1 | jq -j '.applications[0].secret')
-oauthserverurl=$(echo "${response}"| head -n-1 | jq -j '.applications[0].oAuthServerUrl')
+tenantid=$(echo "${response}"| head -n1 | jq -j '.applications[0].tenantId')
+clientid=$(echo "${response}"| head -n1 | jq -j '.applications[0].clientId')
+secret=$(echo "${response}"| head -n1 | jq -j '.applications[0].secret')
+oauthserverurl=$(echo "${response}"| head -n1 | jq -j '.applications[0].oAuthServerUrl')
 appidhost=$(echo "${oauthserverurl}" | awk -F/ '{print $3}')
 
 oc create secret generic bank-oidc-secret --from-literal=OIDC_JWKENDPOINTURL=$oauthserverurl/publickeys --from-literal=OIDC_ISSUERIDENTIFIER=$oauthserverurl --from-literal=OIDC_AUDIENCES=$clientid

--- a/scripts/mapAppIDtoSecrets.sh
+++ b/scripts/mapAppIDtoSecrets.sh
@@ -17,7 +17,7 @@ echo $response
 code=$(echo "${response}" | tail -n1)
 [ "$code" -ne "200" ] && exit 1
 
-accesstoken=$(echo "${response}" | head -n-1 | jq -j '.access_token')
+accesstoken=$(echo "${response}" | head -n1 | jq -j '.access_token')
 
 response=$(curl -v -X GET -w "\n%{http_code}" \
   -H "Content-Type: application/json" \
@@ -29,10 +29,10 @@ echo $response
 code=$(echo "${response}" | tail -n1)
 [ "$code" -ne "200" ] && exit 1
 
-tenantid=$(echo "${response}"| head -n-1 | jq -j '.applications[0].tenantId')
-clientid=$(echo "${response}"| head -n-1 | jq -j '.applications[0].clientId')
-secret=$(echo "${response}"| head -n-1 | jq -j '.applications[0].secret')
-oauthserverurl=$(echo "${response}"| head -n-1 | jq -j '.applications[0].oAuthServerUrl')
+tenantid=$(echo "${response}"| head -n1 | jq -j '.applications[0].tenantId')
+clientid=$(echo "${response}"| head -n1 | jq -j '.applications[0].clientId')
+secret=$(echo "${response}"| head -n1 | jq -j '.applications[0].secret')
+oauthserverurl=$(echo "${response}"| head -n1 | jq -j '.applications[0].oAuthServerUrl')
 appidhost=$(echo "${oauthserverurl}" | awk -F/ '{print $3}')
 
 # Creates secret from application credentials

--- a/scripts/mapAppIDtoSecrets.sh
+++ b/scripts/mapAppIDtoSecrets.sh
@@ -1,3 +1,22 @@
+# Check if ibmcloud is in user's account
+ibmcloud_accountname=$(ibmcloud target --output json | jq -j '.account.name')
+
+## check if account is in quicklabs (labs.cognitiveclass.ai) or workshop clusters account in DEG
+if [ "$ibmcloud_accountname" = "QuickLabs - IBM Skills Network" ]; then
+  echo "\n"
+  echo "WARNING: You're logged in as ${ibmcloud_accountname}"
+  echo "Please log in again using -- ibmcloud login -u YOUR_IBM_CLOUD_EMAIL"
+  echo "and run this script again"
+  exit 1
+elif [ "$ibmcloud_accountname" = "DEGCloud DEGCloud's Account" ]; then
+  echo "\n"
+  echo "WARNING: You're logged in as ${ibmcloud_accountname}"
+  echo "Please log in again using -- ibmcloud login -u YOUR_IBM_CLOUD_EMAIL"
+  echo "and run this script again"
+  exit 1
+fi
+# end check
+
 # Grabs appid-example-bank instance and gets api key and management url from appid-example-bank-credentials
 credentials=$(ibmcloud resource service-keys --instance-name appid-example-bank --output JSON | jq -c '[ .[] | select( .name | contains("appid-example-bank-credentials")) ]' | jq -j '.[0].credentials')
 APIKEY=$(echo "${credentials}" | jq -j '.apikey')


### PR DESCRIPTION
```
Make app id script compatible to macos

`head -n-1` does not work in macos
```
```
Add check if user is in a workshop account

Checks if in DEG account or Cognitive labs account when running
createappid.sh or mapAppIDtoSecrets.sh
```